### PR TITLE
A-14084 Yield the block

### DIFF
--- a/lib/microsoft_graph/collection_association.rb
+++ b/lib/microsoft_graph/collection_association.rb
@@ -169,7 +169,7 @@ class MicrosoftGraph
 
         fetch_next_page
 
-        each(start, &Proc.new)
+        each(start, &Proc.new { yield })
       end
     end
 


### PR DESCRIPTION
Looks like the original gem is no longer being maintained. 

Previously `Proc.new` would use the implicit block, but this is no longer the cause. So we will explicitly pass a block that uses `yield`
