### PR TITLE
A-14356: OneDrive is relying on URI.escape which no longer exists

### DIFF
--- a/lib/microsoft_graph/collection_association.rb
+++ b/lib/microsoft_graph/collection_association.rb
@@ -34,7 +34,7 @@ class MicrosoftGraph
     end
 
     def find(id)
-      if response = graph.service.get("#{path}/#{URI.escape(id.to_s)}")
+      if response = graph.service.get("#{path}/#{URI.encode_www_form_component(id.to_s)}")
         klass = if member_type = specified_member_type(response)
           ClassBuilder.get_namespaced_class(response)
         else
@@ -62,11 +62,11 @@ class MicrosoftGraph
     def query_path
       if @order_by
         order_by_names = @order_by.map do |field|
-          URI.escape OData.convert_to_camel_case(field)
+          URI.encode_www_form_component OData.convert_to_camel_case(field)
         end
         "#{path}?$orderby=#{order_by_names.join(',')}"
       elsif @filter
-        escaped_filters = URI.escape(stringify_filters(@filter))
+        escaped_filters = URI.encode_www_form_component(stringify_filters(@filter))
         "#{path}?$filter=#{escaped_filters}"
       else
         path


### PR DESCRIPTION
## Description

Swap `escape` for `encode_www_form_component` since escape has been deprecated

