### PR TITLE
ENGWORK-5606: More logging

### DIFF
--- a/lib/odata/service.rb
+++ b/lib/odata/service.rb
@@ -172,6 +172,9 @@ module OData
         get_type_by_name(type_name_from_odata_type_field(odata_type_string))
       elsif context = parsed_response["@odata.context"]
         singular, segments = segments_from_odata_context_field(context)
+
+        Rails.logger.info "Segments from odata context field: #{segments.inspect}"
+
         first_entity_type = get_type_by_name("Collection(#{entity_set_by_name(segments.shift).member_type})")
         entity_type = segments.reduce(first_entity_type) do |last_entity_type, segment|
           last_entity_type.member_type.navigation_property_by_name(segment).type


### PR DESCRIPTION
We are currently passing `Collection` into `entity_set_by_name` which is returning `nil`. Downstream, that ends up calling `member_type` on that `nil` and errors. By adding the logging, I am trying to understand what the segments actually are in this case.

We already have some logging that shows us the available sets like:

`EntitySet "Collection" not found. Sets are ["directoryObjects", "devices", "groups", "directoryRoles", "directoryRoleTemplates", "organization", "subscribedSkus", "users", "drives"]`

Hopefully, after this, we'll be able to see something else in segments that we should be grabbing in this case.