### PR TITLE
A-17685 fix one drive

### DIFF
--- a/lib/odata/service.rb
+++ b/lib/odata/service.rb
@@ -175,7 +175,7 @@ module OData
 
         Rails.logger.info "Segments from odata context field: #{segments.inspect}"
 
-        first_entity_type = get_type_by_name("Collection(#{entity_set_by_name(segments.shift).member_type})")
+        first_entity_type = get_type_by_name("Collection(#{entity_set_by_name(segments.shift)&.member_type})")
         entity_type = segments.reduce(first_entity_type) do |last_entity_type, segment|
           last_entity_type.member_type.navigation_property_by_name(segment).type
         end


### PR DESCRIPTION
The gem does some very confusing things. We get a respnse that will look like

```
{"@odata.context":"https://graph.microsoft.com/v1.0/$metadata#Collection(driveItem)/$entity", ... }
```

and the gem will pull out this string, look at what is after the metadata, see that there is a "driveItem" piece and it will use that as part of generating the next collection. 

However the error from #4 we get a response like
```
{ "@odata.context":"https://graph.microsoft.com/v1.0/$metadata#drives/$entity", ... }
```
Which doesn't have this "member type" present. This only seems to happen for OneDrive for business and not the personal ones. 

I can't say I have full context of what is going on, but if we return `nil` from the member type, we end up trying to get the `Collection()` data which appears to allow it to work correctly. 